### PR TITLE
Fix Unable to unserialize value

### DIFF
--- a/src/Helper/BaseHelper.php
+++ b/src/Helper/BaseHelper.php
@@ -143,7 +143,7 @@ class BaseHelper extends AbstractHelper
     public function getIsHoliday($carrier)
     {
         $date = $this->getTimezoneDate('m-d');
-        $holidays = $this->getConfiguration(sprintf("carriers/%s/holidays", $carrier));
+        $holidays = $this->getConfiguration(sprintf("carriers/%s/holidays", $carrier)) ?? '[]';
         $holidays = $this->serializer->unserialize($holidays);
 
         foreach ($holidays as $holiday) {


### PR DESCRIPTION
If holidays is empty, an error is thrown : "Unable to unserialize value"